### PR TITLE
made register and login modals

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -11,7 +11,6 @@ import Banner from './components/banner/banner'
 import { 
 	math, science, history, art, literature, language,
 } from './images'
-import { AuthContext } from './contexts/Auth.context';
 
 const topics = [
 	{ 
@@ -51,33 +50,19 @@ const styles = theme => ({
 	},
 })
 
-class App extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      registerOpen: false,
-    }
-    this.handleClose = this.handleClose.bind(this);
-		this.handleOpen = this.handleOpen.bind(this);
-	}
-
-	handleClose() { this.setState({ registerOpen: false})}
-	handleOpen() { this.setState({ registerOpen: true})}
-
-	static contextType = AuthContext;
+export class App extends Component {
 
   render() {
-		const { classes } = this.props;
-		const { user } = this.context;
-		const { registerOpen } = this.state;
+		const { classes, user, registerOpen,
+			handleModalClose, handleModalOpen } = this.props;
     return (
 			<div className='App'>
 				<div className='banner-container'>
 					<Banner 
 					registerOpen={registerOpen}
 					user={user}
-					handleModalClose={this.handleClose}
-					handleModalOpen={this.handleOpen} />
+					handleModalClose={() => handleModalClose()}
+					handleModalOpen={() => handleModalOpen()} />
 				</div>
 				<Grid className={classes.main_grid} container justify='center' >
 					<Grid 

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -52,15 +52,32 @@ const styles = theme => ({
 })
 
 class App extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      registerOpen: false,
+    }
+    this.handleClose = this.handleClose.bind(this);
+		this.handleOpen = this.handleOpen.bind(this);
+	}
+
+	handleClose() { this.setState({ registerOpen: false})}
+	handleOpen() { this.setState({ registerOpen: true})}
+
 	static contextType = AuthContext;
 
   render() {
 		const { classes } = this.props;
 		const { user } = this.context;
+		const { registerOpen } = this.state;
     return (
 			<div className='App'>
 				<div className='banner-container'>
-					<Banner user={user} />
+					<Banner 
+					registerOpen={registerOpen}
+					user={user}
+					handleModalClose={this.handleClose}
+					handleModalOpen={this.handleOpen} />
 				</div>
 				<Grid className={classes.main_grid} container justify='center' >
 					<Grid 

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -11,6 +11,7 @@ import Banner from './components/banner/banner'
 import { 
 	math, science, history, art, literature, language,
 } from './images'
+import { AuthContext } from './contexts/Auth.context';
 
 const topics = [
 	{ 
@@ -51,12 +52,15 @@ const styles = theme => ({
 })
 
 class App extends Component {
+	static contextType = AuthContext;
+
   render() {
 		const { classes } = this.props;
+		const { user } = this.context;
     return (
 			<div className='App'>
 				<div className='banner-container'>
-					<Banner />
+					<Banner user={user} />
 				</div>
 				<Grid className={classes.main_grid} container justify='center' >
 					<Grid 

--- a/frontend/src/components/banner/banner.js
+++ b/frontend/src/components/banner/banner.js
@@ -19,6 +19,7 @@ const styles = theme => ({
 		backgroundColor: theme.palette.primary.dark,
 		'&:hover': {
 			backgroundColor: theme.palette.primary.dark,
+			color: 'white',
 		},
 		transform: 'translate(-50%, 50%)',
     color: 'white',

--- a/frontend/src/components/banner/banner.js
+++ b/frontend/src/components/banner/banner.js
@@ -1,9 +1,11 @@
 
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { Button, withStyles, Typography } from '@material-ui/core';
+import { Button, withStyles, Typography,
+  Modal, } from '@material-ui/core';
 import SwipeableViews from 'react-swipeable-views';
 import { autoPlay } from 'react-swipeable-views-utils';
+import { Register } from '../../containers';
 
 import { study_banner, study_banner1,
 study_banner2 } from '../../images';
@@ -36,6 +38,14 @@ const styles = theme => ({
 		height: 500,
 		width: '100%',
 		"object-fit": 'cover'
+	},
+	registerPaper: {
+		position: 'absolute',
+		left: '50%',
+		width: '700px',
+		height: '60%',
+		backgroundColor: theme.palette.background.paper,
+		transform: 'translate(-50%, 40%)',
 	}
 })
 
@@ -61,14 +71,20 @@ const Banner = (props) => (
   </Typography>
   {props.user ? ( null ) : (
     <Button 
-      component={Link}
-      to='/register'
+/*       component={Link}
+      to='/register' */
+      onClick={props.handleModalOpen}
       className={props.classes.banner_button}
       children="Sign Up"
       variant='text'
       size='large'
     />
   )}
+  <Modal open={props.registerOpen} onClose={() => props.handleModalClose()}>
+    <div className={props.classes.registerPaper}>
+      <Register handleModalClose={props.handleModalClose} />
+    </div>
+  </Modal>
 </div>
 )
 

--- a/frontend/src/components/banner/banner.js
+++ b/frontend/src/components/banner/banner.js
@@ -59,14 +59,16 @@ const Banner = (props) => (
    noWrap>
     What do you StudY?
   </Typography>
-  <Button 
-    component={Link}
-    to='/register'
-    className={props.classes.banner_button}
-    children="Sign Up"
-    variant='text'
-    size='large'
-  />
+  {props.user ? ( null ) : (
+    <Button 
+      component={Link}
+      to='/register'
+      className={props.classes.banner_button}
+      children="Sign Up"
+      variant='text'
+      size='large'
+    />
+  )}
 </div>
 )
 

--- a/frontend/src/components/header/header.js
+++ b/frontend/src/components/header/header.js
@@ -3,7 +3,9 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import {
 	Button, AppBar, Typography, Toolbar, withStyles,
+	Modal,
 } from '@material-ui/core';
+import { Login, Register } from '../../containers';
 import PropTypes from 'prop-types';
 
 const styles = theme => ({
@@ -18,11 +20,20 @@ const styles = theme => ({
 		marginRight: theme.spacing.unit,
 		marginTop: 'auto',
 		marginBottom: 'auto',
-	}
+	},
+	paper: {
+		position: 'absolute',
+		left: '50%',
+		width: '600px',
+		height: '50%',
+		backgroundColor: theme.palette.background.paper,
+		transform: 'translate(-50%, 50%)',
+	},
 })
 
 export function Header({
-	user, onLogout, classes
+	user, handleLogout, classes, handleModalClose,
+	handleModalOpen, loginOpen, 
 }) {
 	return (
 		<AppBar position='static' >
@@ -49,14 +60,15 @@ export function Header({
 							className={classes.logout_button}
 							color='inherit'
 							children="logout"
-							onClick={onLogout}
+							onClick={() => handleLogout()}
 						/>
 					</div>
 				) : (
 					<div>
 						<Button
-							component={Link}
-							to="/login"
+/* 							component={Link}
+							to="/login" */
+							onClick={() => handleModalOpen('login')}
 							className='login-button'
 							children="Login"
 							color='inherit' />
@@ -67,6 +79,12 @@ export function Header({
 							color='inherit'
 							children="Register"
 						/>
+
+						<Modal open={loginOpen} onClose={() => handleModalClose('login')}>
+							<div className={classes.paper}>
+								<Login />
+							</div>
+						</Modal>
 					</div>
 				)}
 		</Toolbar>
@@ -76,12 +94,12 @@ export function Header({
 	
 Header.propTypes = { 
 	user: PropTypes.object,
-	onLogout: PropTypes.func,
+	handleLogout: PropTypes.func,
 }
 
 Header.defaultProps = {
 	user: null,
-	onLogout: undefined,
+	handleLogout: undefined,
 }
 
 export default withStyles(styles)(Header);

--- a/frontend/src/components/header/header.js
+++ b/frontend/src/components/header/header.js
@@ -21,7 +21,7 @@ const styles = theme => ({
 		marginTop: 'auto',
 		marginBottom: 'auto',
 	},
-	paper: {
+	loginPaper: {
 		position: 'absolute',
 		left: '50%',
 		width: '600px',
@@ -29,11 +29,19 @@ const styles = theme => ({
 		backgroundColor: theme.palette.background.paper,
 		transform: 'translate(-50%, 50%)',
 	},
+	registerPaper: {
+		position: 'absolute',
+		left: '50%',
+		width: '700px',
+		height: '60%',
+		backgroundColor: theme.palette.background.paper,
+		transform: 'translate(-50%, 40%)',
+	}
 })
 
 export function Header({
 	user, handleLogout, classes, handleModalClose,
-	handleModalOpen, loginOpen, 
+	handleModalOpen, loginOpen, registerOpen
 }) {
 	return (
 		<AppBar position='static' >
@@ -73,16 +81,22 @@ export function Header({
 							children="Login"
 							color='inherit' />
 						<Button 
-							component={Link} 
-							to="/register"
+/* 							component={Link} 
+							to="/register" */
+							onClick={() => handleModalOpen('register')}
 							className='register-button'
 							color='inherit'
 							children="Register"
 						/>
 
 						<Modal open={loginOpen} onClose={() => handleModalClose('login')}>
-							<div className={classes.paper}>
+							<div className={classes.loginPaper}>
 								<Login />
+							</div>
+						</Modal>
+						<Modal open={registerOpen} onClose={() => handleModalClose('register')}>
+							<div className={classes.registerPaper}>
+								<Register handleModalClose={handleModalClose} />
 							</div>
 						</Modal>
 					</div>

--- a/frontend/src/components/header/header.js
+++ b/frontend/src/components/header/header.js
@@ -3,15 +3,19 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import {
 	Button, AppBar, Typography, Toolbar, withStyles,
-	Modal,
+	Modal, Divider
 } from '@material-ui/core';
 import { Login, Register } from '../../containers';
 import PropTypes from 'prop-types';
 
 const styles = theme => ({
 	title: {
-		flex: 1,
+		'&:hover': {
+			backgroundColor: theme.palette.primary,
+			color: 'white',
+		},
 	},
+	divide: { flex: 1 },
 	right_actions: {
 		display: 'flex',
 		flex: -1,
@@ -55,6 +59,7 @@ export function Header({
 					color='inherit'>
 					studY
 				</Typography>
+				<div className={classes.divide} />
 				{user ? ( 
 					<div className={classes.right_actions}>
 						<Typography

--- a/frontend/src/components/login/login.js
+++ b/frontend/src/components/login/login.js
@@ -90,7 +90,7 @@ export default withFormik({
   handleSubmit: (user, { props, setErrors, setSubmitting }) => {
     loginUser(user).then(result => {
       props.onLogin(result.token)
-    }).then(() => props.history.push('/'))
+    })// .then(() => props.history.push('/'))
     .catch(error => {
 			setErrors({ loginForm: error.message});
 			setSubmitting(false);

--- a/frontend/src/components/login/login.module.css
+++ b/frontend/src/components/login/login.module.css
@@ -18,7 +18,7 @@ body {
     -ms-flex-align: center;
     align-items: center;
     overflow-x: hidden;
-    min-height: 100vh;
+    min-height: 50vh;
 }
 
 .PageColumn_left {
@@ -27,7 +27,7 @@ body {
 
 .Art {
     background-image: url('../../images/sideImg.png');
-    height: 100vh;
+    height: 50vh;
     background-repeat: no-repeat;
     background-size: cover;
 }

--- a/frontend/src/components/register/register.js
+++ b/frontend/src/components/register/register.js
@@ -201,7 +201,7 @@ export default withFormik({
 	}),
 	handleSubmit: (applicant, { props, setErrors, setSubmitting }) => {
 		registerUser(applicant).then(() => {
-			props.history.push('/')
+			props.handleModalClose('register');
 		}).catch(error => {
 			setErrors({ registerForm: error.message });
 			setSubmitting(false);

--- a/frontend/src/components/register/register.module.css
+++ b/frontend/src/components/register/register.module.css
@@ -27,7 +27,7 @@ body {
     -ms-flex-align: center;
     align-items: center;
     overflow-x: hidden;
-    min-height: 100vh;
+    min-height: 60vh;
 }
 
 .PageColumn_left {
@@ -36,7 +36,7 @@ body {
 
 .Art {
     background-image: url('../../images/sideImg.png');
-    height: 100vh;
+    height: 60vh;
 
     background-repeat: no-repeat;
     background-size: cover;

--- a/frontend/src/containers/App.js
+++ b/frontend/src/containers/App.js
@@ -1,0 +1,37 @@
+
+import React, { Component } from 'react';
+
+import App from '../App';
+import { AuthContext } from '../contexts/Auth.context';
+
+class appWrapper extends Component  {
+  static contextType = AuthContext;
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      registerOpen: false,
+    }
+    this.handleClose = this.handleClose.bind(this);
+		this.handleOpen = this.handleOpen.bind(this);
+	}
+
+	handleClose() { this.setState({ registerOpen: false})}
+	handleOpen() { this.setState({ registerOpen: true})}
+
+  render() {
+    const { user } = this.context;
+    return ( 
+      <App 
+      {...this.props}
+      {...this.state} 
+      user={user}
+      handleModalClose={this.handleClose}
+      handleModalOpen={this.handleOpen}
+      handleLogout={this.handleLogout}
+       />
+    )
+  }
+}
+
+export default appWrapper;

--- a/frontend/src/containers/header.js
+++ b/frontend/src/containers/header.js
@@ -11,7 +11,7 @@ class headerWrapper extends Component  {
     super(props);
     this.state = {
       loginOpen: false,
-      registerOpen: true,
+      registerOpen: false,
     }
     this.handleClose = this.handleClose.bind(this);
     this.handleOpen = this.handleOpen.bind(this);

--- a/frontend/src/containers/header.js
+++ b/frontend/src/containers/header.js
@@ -7,9 +7,48 @@ import { AuthContext } from '../contexts/Auth.context';
 class headerWrapper extends Component  {
   static contextType = AuthContext;
 
+  constructor(props) {
+    super(props);
+    this.state = {
+      loginOpen: false,
+      registerOpen: false,
+    }
+    this.handleClose = this.handleClose.bind(this);
+    this.handleOpen = this.handleOpen.bind(this);
+    this.handleLogout = this.handleLogout.bind(this);
+  }
+
+  handleClose(modal) {
+    if(modal === 'login') {
+      this.setState({ loginOpen: false })
+    } else if (modal === 'register') {
+      this.setState({ registerOpen: false })
+    }
+  }
+
+  handleOpen(modal) {
+    if(modal === 'login') {
+      this.setState({ loginOpen: true })
+    } else if (modal === 'register') {
+      this.setState({ registerOpen: true })
+    }
+  }
+
+  handleLogout() {
+    this.context.onLogout();
+    this.handleClose('login');
+  }
+
   render() {
+    const { user } = this.context;
     return ( 
-      <Header {...this.props} {...this.context} />
+      <Header 
+      {...this.state} 
+      user={user}
+      handleModalClose={this.handleClose}
+      handleModalOpen={this.handleOpen}
+      handleLogout={this.handleLogout}
+       />
     )
   }
 }

--- a/frontend/src/containers/header.js
+++ b/frontend/src/containers/header.js
@@ -11,7 +11,7 @@ class headerWrapper extends Component  {
     super(props);
     this.state = {
       loginOpen: false,
-      registerOpen: false,
+      registerOpen: true,
     }
     this.handleClose = this.handleClose.bind(this);
     this.handleOpen = this.handleOpen.bind(this);

--- a/frontend/src/containers/index.js
+++ b/frontend/src/containers/index.js
@@ -1,3 +1,4 @@
+export { default as App } from './App';
 export { default as EventListPage } from './EventListPage/EventListPage'
 export { default as Header } from './header';
 export { default as EventPage } from './EventPage/EventPage';

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -59,8 +59,6 @@ ReactDOM.render(
 				<AuthProvider>
 					<Header />
 					<Route exact path="/" component={App} />
-					<Route exact path="/register" component={Register} />
-					<Route exact path="/login" component={Login} />
 					<Route exact path="/eventform" component={EventForm} />
 				</AuthProvider>
   

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -2,10 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { BrowserRouter as Router, Route } from 'react-router-dom';
 import './index.css';
-import App from './App';
+// import App from './App';
 import EventForm from './containers/eventForm';
 import Subtopic from './components/Subtopic/Subtopic';
-import { EventListPage, Header, Register, Login, EventPage } from './containers';
+import { EventListPage, Header, Register, Login, EventPage,
+	App } from './containers';
 import * as serviceWorker from './serviceWorker';
 
 // import { Provider } from 'react-redux';


### PR DESCRIPTION
close #90 #77 

Made `Header` render `Login` and `Register` as modals. Also fixed some visual bugs. (banner signup button, button hover colors)

**todo**: still need to finish event form.

![modals](https://user-images.githubusercontent.com/19293171/47981969-ed43db00-e09b-11e8-9495-bcdc29672a0e.gif)
